### PR TITLE
Minor changes to make build work on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: required
+dist: trusty
 language: cpp
 before_install: 
   - sudo apt-get -qq update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,6 @@
+sudo: required
 language: cpp
+before_install: 
+  - sudo apt-get -qq update
+  - sudo apt-get -y install bison
 script: ./bootstrap && ./configure && make && make check

--- a/bootstrap
+++ b/bootstrap
@@ -1,5 +1,5 @@
 #! /bin/sh
-aclocal \
+aclocal -I m4 \
 && autoheader \
 && automake --gnu --add-missing \
 && autoconf 

--- a/configure.ac
+++ b/configure.ac
@@ -28,7 +28,6 @@
 AC_INIT(souffle, 1.0, [programanalysis_au_grp@oracle.com])
 AC_PREREQ(2.68)
 AC_COPYRIGHT(['2013-15 Oracle and/or its affiliates'])
-AC_CONFIG_MACRO_DIRS([m4])
 
 AC_CANONICAL_TARGET # target_cpu, target_vendor, and target_os
 AC_CANONICAL_BUILD  # build_cpu, build_vendor, and build_os
@@ -107,7 +106,6 @@ AC_FUNC_ALLOCA
 AC_CHECK_HEADERS([arpa/inet.h fcntl.h float.h inttypes.h libintl.h limits.h malloc.h memory.h netdb.h stddef.h stdint.h stdlib.h string.h strings.h sys/time.h sys/timeb.h unistd.h wchar.h wctype.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
-AC_CHECK_HEADER_STDBOOL
 AC_C_INLINE
 AC_TYPE_INT16_T
 AC_TYPE_INT32_T


### PR DESCRIPTION
Set Travis to use the ubuntu trusty beta; currently unable to build on 12.04 (raised #9 for the underlying issues there). Other changes may be mooted by trusty, but still should improve compatibility slightly
